### PR TITLE
Add .travis.yml file

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,21 @@
+language: php
+dist: trusty
+
+php:
+  - 5.6
+  - 7.0
+
+matrix:
+  fast_finish: true
+  allow_failures:
+    - php: nightly
+
+branches:
+  only:
+    - master
+
+install:
+  - travis_retry composer install --no-interaction --prefer-dist --no-suggest
+
+script:
+  - ./vendor/bin/phpunit


### PR DESCRIPTION
Supports building on PHP 5.6 and 7.0.  These versions were selected since that is what is in `composer.json` for PHP versions.  However, the PHP 5.6 build fails due to the spatie/phpunit-watcher dependency requiring PHP >=7.0.